### PR TITLE
Update RigelEngine to latest release

### DIFF
--- a/RigelEngine/macsourceports_universal2.sh
+++ b/RigelEngine/macsourceports_universal2.sh
@@ -1,5 +1,5 @@
 # game/app specific values
-export APP_VERSION="0.8.5"
+export APP_VERSION="0.9.1"
 export PRODUCT_NAME="RigelEngine"
 export PROJECT_NAME="RigelEngine"
 export PORT_NAME="RigelEngine"
@@ -7,7 +7,7 @@ export ICONSFILENAME="RigelEngine"
 export EXECUTABLE_NAME="RigelEngine"
 export PKGINFO="APPLROTT"
 export GIT_DEFAULT_BRANCH="master"
-export GIT_TAG="v0.8.5"
+export GIT_TAG="v0.9.1"
 
 #constants
 source ../common/constants.sh


### PR DESCRIPTION
See https://github.com/lethal-guitar/RigelEngine/releases/tag/v0.9.1

EDIT: I just noticed a crash bug in the latest version, and I'm working on pushing out a fix as version 0.9.1 - will update this PR once that's done.

EDIT: Ok, that's sorted now!